### PR TITLE
Improve Admin card layout

### DIFF
--- a/src/components/AdminCard.tsx
+++ b/src/components/AdminCard.tsx
@@ -8,7 +8,7 @@ export interface Admin {
 
 export default function AdminCard({ admin }: { admin: Admin }) {
   return (
-    <div className="p-4 border rounded bg-white dark:bg-neutral-800 flex flex-col items-center gap-2 text-center w-full aspect-[2/3]">
+    <div className="p-4 border rounded bg-white dark:bg-neutral-800 flex flex-col items-center gap-2 text-center w-full aspect-square">
       <div className="h-24 w-24 rounded-full bg-neutral-300 dark:bg-neutral-700 animate-pulse" />
       <h3 className="font-semibold">{admin.name}</h3>
       <p className="text-sm text-neutral-600 dark:text-neutral-300">{admin.role}</p>


### PR DESCRIPTION
## Summary
- adjust `AdminCard` aspect ratio to be square instead of 2/3

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68819fe4700c8328852fcf1dd87c0ea4